### PR TITLE
Replaced GH workflow Ubuntu 20.04 and 22.04 by 22.04 and 24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-20.04, macos-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, ubuntu-22.04, macos-latest, macos-13, windows-latest]
     steps:
       - uses: actions/checkout @v4
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
Resolves #23 